### PR TITLE
Export common errors from decode methods.

### DIFF
--- a/error/error.go
+++ b/error/error.go
@@ -1,0 +1,59 @@
+package error
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidSetID is returned when the set id is 0.
+var ErrInvalidSetID = errors.New("failed to decodeSet / invalid setID")
+
+// ErrNoFieldsDecoded is returned when no field was decoded from the data.
+var ErrNoFieldsDecoded = errors.New("no field decoded from data")
+
+var _ error = &InvalidProtocolVersionError{}
+
+// InvalidProtocolVersionError indicates the received version is invalid.
+type InvalidProtocolVersionError struct {
+	// Expected is the expected version.
+	Expected uint16
+	// Received is the received version.
+	Received uint16
+	// Protocol is the protocol name.
+	Protocol string
+}
+
+// Error implements error.
+func (e *InvalidProtocolVersionError) Error() string {
+	return fmt.Sprintf("invalid %s version (expected: %d) (received: %d)",
+		e.Protocol, e.Expected, e.Received)
+}
+
+var _ error = &CombinedErrors{}
+
+// CombinedErrors is a collection of errors.
+type CombinedErrors struct {
+	Errors []error
+}
+
+// Error implements error.
+func (e *CombinedErrors) Error() string {
+	if len(e.Errors) == 1 {
+		return e.Errors[0].Error()
+	}
+	var errMsg bytes.Buffer
+	errMsg.WriteString("Multiple errors:")
+	for _, subError := range e.Errors {
+		errMsg.WriteString("\n- " + subError.Error())
+	}
+	return errMsg.String()
+}
+
+// CombineErrors returns a CombinedErrors containing the given errors.
+func CombineErrors(errorSlice ...error) (err error) {
+	if len(errorSlice) == 0 {
+		return nil
+	}
+	return &CombinedErrors{Errors: errorSlice}
+}

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -28,13 +28,15 @@ import (
 	"errors"
 )
 
+// ErrReaderNotEnoughBytes indicates the reader does not have enough bytes to
+// decode the next value.
+var ErrReaderNotEnoughBytes = errors.New("can not read the data")
+
 // Reader represents the data bytes for reading
 type Reader struct {
 	data  []byte
 	count int
 }
-
-var errReader = errors.New("can not read the data")
 
 // NewReader constructs a reader
 func NewReader(b []byte) *Reader {
@@ -46,7 +48,7 @@ func NewReader(b []byte) *Reader {
 // Uint8 reads a byte
 func (r *Reader) Uint8() (uint8, error) {
 	if len(r.data) < 1 {
-		return 0, errReader
+		return 0, ErrReaderNotEnoughBytes
 	}
 
 	d := r.data[0]
@@ -58,7 +60,7 @@ func (r *Reader) Uint8() (uint8, error) {
 // Uint16 reads two bytes as big-endian
 func (r *Reader) Uint16() (uint16, error) {
 	if len(r.data) < 2 {
-		return 0, errReader
+		return 0, ErrReaderNotEnoughBytes
 	}
 
 	d := binary.BigEndian.Uint16(r.data)
@@ -70,7 +72,7 @@ func (r *Reader) Uint16() (uint16, error) {
 // Uint32 reads four bytes as big-endian
 func (r *Reader) Uint32() (uint32, error) {
 	if len(r.data) < 4 {
-		return 0, errReader
+		return 0, ErrReaderNotEnoughBytes
 	}
 
 	d := binary.BigEndian.Uint32(r.data)
@@ -82,7 +84,7 @@ func (r *Reader) Uint32() (uint32, error) {
 // Uint64 reads eight bytes as big-endian
 func (r *Reader) Uint64() (uint64, error) {
 	if len(r.data) < 8 {
-		return 0, errReader
+		return 0, ErrReaderNotEnoughBytes
 	}
 
 	d := binary.BigEndian.Uint64(r.data)
@@ -94,7 +96,7 @@ func (r *Reader) Uint64() (uint64, error) {
 // Read reads n bytes and returns it
 func (r *Reader) Read(n int) ([]byte, error) {
 	if len(r.data) < n {
-		return []byte{}, errReader
+		return nil, ErrReaderNotEnoughBytes
 	}
 
 	d := r.data[:n]
@@ -115,7 +117,7 @@ func (r *Reader) PeekUint16() (res uint16, err error) {
 // Peek returns the next n bytes in the reader without advancing in the stream
 func (r *Reader) Peek(n int) ([]byte, error) {
 	if len(r.data) < n {
-		return []byte{}, errReader
+		return nil, ErrReaderNotEnoughBytes
 	}
 	return r.data[:n], nil
 }


### PR DESCRIPTION
This PR is a minor improvement for error handling. It defines and exports the common errors in the protocol decode methods. 
- Usually, the same error would occur repeatedly, like `fmt.Errorf("invalid netflow version (%d)", h.Version)`.
  With predefined errors, it would be easier for the user of the library to aggregate the error stats.
- The static errors (created by `errors.New`) are also predefined and reused, instead of creating new one on the fly.

